### PR TITLE
Adds docker-compose support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,12 @@ LABEL maintainer="olala7846@gmail.com"
 # Install Dataspeed DBW https://goo.gl/KFSYi1 from binary
 # adding Dataspeed server to apt
 RUN sh -c 'echo "deb [ arch=amd64 ] http://packages.dataspeedinc.com/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-dataspeed-public.list'
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FF6D3CDA
-RUN apt-get update
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FF6D3CDA && apt-get update
 
 # setup rosdep
 RUN sh -c 'echo "yaml http://packages.dataspeedinc.com/ros/ros-public-'$ROS_DISTRO'.yaml '$ROS_DISTRO'" > /etc/ros/rosdep/sources.list.d/30-dataspeed-public-'$ROS_DISTRO'.list'
 RUN rosdep update
-RUN apt-get install -y ros-$ROS_DISTRO-dbw-mkz
-RUN apt-get upgrade -y
-# end installing Dataspeed DBW
+RUN apt-get install -y ros-$ROS_DISTRO-dbw-mkz && apt-get upgrade -y
 
 # install python packages
 RUN apt-get install -y python-pip
@@ -21,9 +18,9 @@ COPY requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt
 
 # install required ros dependencies
-RUN apt-get install -y ros-$ROS_DISTRO-cv-bridge
-RUN apt-get install -y ros-$ROS_DISTRO-pcl-ros
-RUN apt-get install -y ros-$ROS_DISTRO-image-proc
+RUN apt-get install -y ros-$ROS_DISTRO-cv-bridge \
+                       ros-$ROS_DISTRO-pcl-ros   \
+                       ros-$ROS_DISTRO-image-proc
 
 # socket io
 RUN apt-get install -y netbase

--- a/README.md
+++ b/README.md
@@ -20,6 +20,26 @@ This is the project repo for the final project of the Udacity Self-Driving Car N
 ### Docker Installation
 [Install Docker](https://docs.docker.com/engine/installation/)
 
+#### With docker-compose
+
+##### Run
+```bash
+docker-compose up
+```
+
+##### Clean up
+```bash
+docker-compose down -v
+```
+
+##### Full Clean up
+Delete the image file
+Will rebuild when `docker-compose up` again
+```bash
+docker-compose down -v --rmi all
+```
+
+#### Without docker-compose
 Build the docker container
 ```bash
 docker build . -t capstone

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3"
+services:
+  ros:
+    build: .
+    volumes:
+      - ".:/capstone"
+      - "/tmp/log:/root/.ros/"
+
+    ports:
+      - "4567:4567"
+      - "11311:11311"
+
+    command: bash -c "catkin_make && source devel/setup.sh && roslaunch launch/styx.launch"


### PR DESCRIPTION
Having a docker-compose file makes the initial set up process a bit easier.
* If we decide to use a _CI tool_, it will be simpler to set up with docker-compose file
* If other people want to try our project, one command(`docker-compose up`) is enough to boot up the project.

## [New] With docker-compose

### Run
```bash
docker-compose up
```

### Clean up
```bash
docker-compose down -v
```

### Full Clean up
* Delete the image file
* Will rebuild an image when `docker-compose up` again
```bash
docker-compose down -v --rmi all
```

## [Current] Without docker-compose

### Build the docker container
```bash
docker build . -t capstone
```

### Run the docker file
```bash
docker run -p 4567:4567 -v $PWD:/capstone -v /tmp/log:/root/.ros/ --rm -it capstone
```
