### PR TITLE
[hotfix] Pillow Version Update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,13 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FF6D3CDA && apt-get
 
 # setup rosdep
 RUN sh -c 'echo "yaml http://packages.dataspeedinc.com/ros/ros-public-'$ROS_DISTRO'.yaml '$ROS_DISTRO'" > /etc/ros/rosdep/sources.list.d/30-dataspeed-public-'$ROS_DISTRO'.list'
-RUN rosdep update
+RUN rosdep update && apt-get update
 RUN apt-get install -y ros-$ROS_DISTRO-dbw-mkz && apt-get upgrade -y
 
 # install python packages
 RUN apt-get install -y python-pip
 COPY requirements.txt ./requirements.txt
-RUN pip install -r requirements.txt
+RUN pip install -U pip && pip install -r requirements.txt
 
 # install required ros dependencies
 RUN apt-get install -y ros-$ROS_DISTRO-cv-bridge \

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ attrdict==2.0.0
 eventlet==0.19.0
 python-socketio==1.6.1
 numpy==1.13.1
-Pillow==2.2.1
+Pillow==4.3.0
 scipy==0.19.1
 keras==2.0.8
 tensorflow==1.3.0


### PR DESCRIPTION
## Summary
There is an issue with the current Pillow version in the upstream [udacity/CarND-Capstone](https://github.com/udacity/CarND-Capstone).

In order to generate *image Msgs*, it requires the minimum version(4.3.0) of Pillow. 
The reason it occurs to Docker is that Docker strictly follows `requirements.txt`

## Related Issues in the Upstream
1. [#147](https://github.com/udacity/CarND-Capstone/issues/147)
2. [#107](https://github.com/udacity/CarND-Capstone/issues/107)
3. [#109](https://github.com/udacity/CarND-Capstone/pull/109)

